### PR TITLE
Implement message-based conversations in support tickets

### DIFF
--- a/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/DTO/request/MessageRequestDTO.java
+++ b/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/DTO/request/MessageRequestDTO.java
@@ -1,0 +1,9 @@
+package tech.zeta.mavericks.digital_insurance_management_system.DTO.request;
+
+import lombok.Data;
+
+@Data
+public class MessageRequestDTO {
+    private Long authorId;   // ID of the user or admin sending the message
+    private String content;  // Message text
+}

--- a/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/DTO/request/SupportTicketUpdateDTO.java
+++ b/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/DTO/request/SupportTicketUpdateDTO.java
@@ -4,7 +4,7 @@ import lombok.Data;
 
 @Data
 public class SupportTicketUpdateDTO {
-    private String response;  // Admin's reply
-    private String status;    // RESOLVED or CLOSED
+    private String status;   // e.g., OPEN, IN_PROGRESS, RESOLVED, CLOSED
 }
+
 

--- a/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/DTO/response/MessageResponseDTO.java
+++ b/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/DTO/response/MessageResponseDTO.java
@@ -1,0 +1,16 @@
+package tech.zeta.mavericks.digital_insurance_management_system.DTO.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Date;
+
+@Data @AllArgsConstructor @NoArgsConstructor
+public class MessageResponseDTO {
+    private Long id;
+    private Long authorId;
+    private String content;
+    private Date timestamp;
+}
+

--- a/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/DTO/response/SupportTicketResponseDTO.java
+++ b/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/DTO/response/SupportTicketResponseDTO.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import tech.zeta.mavericks.digital_insurance_management_system.enums.TicketStatus;
 
 import java.sql.Date;
+import java.util.List;
 
 @Data
 public class SupportTicketResponseDTO {
@@ -14,8 +15,9 @@ public class SupportTicketResponseDTO {
     private String subject;
     private String description;
     private TicketStatus status;
-    private String response;
     private Date createdAt;
     private Date resolvedAt;
+
+    private List<MessageResponseDTO> messages;
 }
 

--- a/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/controller/SupportTicketController.java
+++ b/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/controller/SupportTicketController.java
@@ -1,11 +1,42 @@
-//package tech.zeta.mavericks.digital_insurance_management_system.controller;
-//
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.web.bind.annotation.RestController;
-//import tech.zeta.mavericks.digital_insurance_management_system.service.SupportTicketService;
-//
-//@RestController public class SupportTicketController {
-//
-//    @Autowired
-//    private SupportTicketService supportTicketService;
-//}
+package tech.zeta.mavericks.digital_insurance_management_system.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import tech.zeta.mavericks.digital_insurance_management_system.DTO.request.MessageRequestDTO;
+import tech.zeta.mavericks.digital_insurance_management_system.DTO.request.SupportTicketRequestDTO;
+import tech.zeta.mavericks.digital_insurance_management_system.DTO.request.SupportTicketUpdateDTO;
+import tech.zeta.mavericks.digital_insurance_management_system.DTO.response.MessageResponseDTO;
+import tech.zeta.mavericks.digital_insurance_management_system.DTO.response.SupportTicketResponseDTO;
+import tech.zeta.mavericks.digital_insurance_management_system.service.SupportTicketService;
+
+@RestController
+@RequestMapping("/tickets")
+public class SupportTicketController {
+
+    private SupportTicketService ticketService;
+
+    @PostMapping
+    public ResponseEntity<SupportTicketResponseDTO> createTicket(@RequestBody SupportTicketRequestDTO request) {
+        return ResponseEntity.ok(ticketService.createSupportTicket(request));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SupportTicketResponseDTO> getTicket(@PathVariable Long id) {
+        return ResponseEntity.ok(ticketService.getTicketByTicketId(id));
+    }
+
+
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<SupportTicketResponseDTO> updateStatus(
+            @PathVariable Long id,
+            @RequestBody SupportTicketUpdateDTO updateDTO) {
+        return ResponseEntity.ok(ticketService.updateSupportTicket(id, updateDTO));
+    }
+
+    @PostMapping("/{id}/messages")
+    public ResponseEntity<MessageResponseDTO> addMessage(
+            @PathVariable Long id,
+            @RequestBody MessageRequestDTO request) {
+        return ResponseEntity.ok(ticketService.addMessage(id, request));
+    }
+}

--- a/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/entity/Message.java
+++ b/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/entity/Message.java
@@ -1,0 +1,35 @@
+package tech.zeta.mavericks.digital_insurance_management_system.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import tech.zeta.mavericks.digital_insurance_management_system.enums.MessageStatus;
+
+import java.sql.Date;
+
+@Entity
+@Table(name = "ticket_messages")
+@Data
+public class Message {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Link to ticket
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "ticket_id", nullable = false)
+    private SupportTicket ticket;
+
+    // Who wrote the message (User or Admin)
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private MessageStatus status;
+
+    private Date timestamp;
+}

--- a/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/entity/SupportTicket.java
+++ b/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/entity/SupportTicket.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import tech.zeta.mavericks.digital_insurance_management_system.enums.TicketStatus;
 
 import java.sql.Date;
+import java.util.List;
 
 @Data
 @Entity
@@ -40,8 +41,8 @@ public class SupportTicket {
     @Column(nullable = false, length = 20)
     private TicketStatus status;
 
-    @Column(columnDefinition = "TEXT")
-    private String response;
+    @OneToMany(mappedBy = "ticket", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Message> responses;
 
     @Column(nullable = false)
     private Date createdAt;

--- a/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/enums/MessageStatus.java
+++ b/backend/digital-insurance-management-system/src/main/java/tech/zeta/mavericks/digital_insurance_management_system/enums/MessageStatus.java
@@ -1,0 +1,8 @@
+package tech.zeta.mavericks.digital_insurance_management_system.enums;
+
+public enum MessageStatus {
+        SENT,
+        EDITED,
+        DELETED
+
+}


### PR DESCRIPTION
 - Removed response from SupportTicket.

 - Added MessageRequestDTO / MessageResponseDTO.

 - Updated SupportTicketResponseDTO to include messages.

 - updateSupportTicket now handles status updates only.

 - Added /tickets/{id}/messages endpoint for posting messages.