### PR TITLE
Fixed the empty catch statement

### DIFF
--- a/frontend/src/store/ClaimsManagementStore/index.js
+++ b/frontend/src/store/ClaimsManagementStore/index.js
@@ -272,7 +272,7 @@ export default {
       try {
         await requestWithAuth("PATCH", `/user/policy/ncb/${userPolicyId}`);
       } catch (error) {
-        
+        console.error("Failed to update no claim bonus", error);
       }
     },
   },


### PR DESCRIPTION
Fixing an empty catch statement in Claims store